### PR TITLE
enable-node v0.0.2

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -39,11 +39,6 @@ api = "0.7"
     version = "3.0.1"
 
   [[order.group]]
-    id = "ninech/buildpack-ruby-enable-node"
-    optional = true
-    version = "0.0.1"
-
-  [[order.group]]
     id = "paketo-buildpacks/yarn"
     optional = true
     version = "1.2.0"
@@ -77,6 +72,11 @@ api = "0.7"
     optional = true
     version = "4.5.5"
 
+  [[order.group]]
+    id = "ninech/buildpack-ruby-enable-node"
+    optional = true
+    version = "0.0.2"
+
 [[order]]
 
   [[order.group]]
@@ -100,11 +100,6 @@ api = "0.7"
     id = "paketo-buildpacks/node-engine"
     optional = true
     version = "3.0.1"
-
-  [[order.group]]
-    id = "ninech/buildpack-ruby-enable-node"
-    optional = true
-    version = "0.0.1"
 
   [[order.group]]
     id = "paketo-buildpacks/yarn"
@@ -140,6 +135,11 @@ api = "0.7"
     optional = true
     version = "4.5.5"
 
+  [[order.group]]
+    id = "ninech/buildpack-ruby-enable-node"
+    optional = true
+    version = "0.0.2"
+
 [[order]]
 
   [[order.group]]
@@ -163,11 +163,6 @@ api = "0.7"
     id = "paketo-buildpacks/node-engine"
     optional = true
     version = "3.0.1"
-
-  [[order.group]]
-    id = "ninech/buildpack-ruby-enable-node"
-    optional = true
-    version = "0.0.1"
 
   [[order.group]]
     id = "paketo-buildpacks/yarn"
@@ -203,6 +198,11 @@ api = "0.7"
     optional = true
     version = "4.5.5"
 
+  [[order.group]]
+    id = "ninech/buildpack-ruby-enable-node"
+    optional = true
+    version = "0.0.2"
+
 [[order]]
 
   [[order.group]]
@@ -226,11 +226,6 @@ api = "0.7"
     id = "paketo-buildpacks/node-engine"
     optional = true
     version = "3.0.1"
-  
-  [[order.group]]
-    id = "ninech/buildpack-ruby-enable-node"
-    optional = true
-    version = "0.0.1"
 
   [[order.group]]
     id = "paketo-buildpacks/yarn"
@@ -266,6 +261,11 @@ api = "0.7"
     optional = true
     version = "4.5.5"
 
+  [[order.group]]
+    id = "ninech/buildpack-ruby-enable-node"
+    optional = true
+    version = "0.0.2"
+
 [[order]]
 
   [[order.group]]
@@ -289,11 +289,6 @@ api = "0.7"
     id = "paketo-buildpacks/node-engine"
     optional = true
     version = "3.0.1"
-
-  [[order.group]]
-    id = "ninech/buildpack-ruby-enable-node"
-    optional = true
-    version = "0.0.1"
 
   [[order.group]]
     id = "paketo-buildpacks/yarn"
@@ -328,6 +323,11 @@ api = "0.7"
     id = "paketo-buildpacks/image-labels"
     optional = true
     version = "4.5.5"
+
+  [[order.group]]
+    id = "ninech/buildpack-ruby-enable-node"
+    optional = true
+    version = "0.0.2"
 
 [[order]]
 

--- a/package.toml
+++ b/package.toml
@@ -6,7 +6,7 @@
   uri = "ghcr.io/ninech/buildpack-bundle-install:0.0.1"
 
 [[dependencies]]
-  uri = "ghcr.io/ninech/buildpack-ruby-enable-node:0.0.1"
+  uri = "ghcr.io/ninech/buildpack-ruby-enable-node:0.0.2"
 
 [[dependencies]]
   uri = "urn:cnb:registry:paketo-buildpacks/bundler@0.7.26"


### PR DESCRIPTION
This bumps the enable-node buildpack to v0.0.2 and puts it at the end of the order